### PR TITLE
Fix: Reporting wrong axis ranges to uinput when swap_axis is used

### DIFF
--- a/driver.c
+++ b/driver.c
@@ -796,9 +796,14 @@ int main(int argc, char **argv) {
 	uidev.id.product = 0x1;
 	uidev.id.version = 1;
 	uidev.absmin[ABS_X] = 0;
-	uidev.absmax[ABS_X] = cliente.resx-1;
 	uidev.absmin[ABS_Y] = 0;
-	uidev.absmax[ABS_Y] = cliente.resy-1;
+	if (cliente.swap_axis) {
+		uidev.absmax[ABS_X] = cliente.resy-1;
+		uidev.absmax[ABS_Y] = cliente.resx-1;
+	} else {
+		uidev.absmax[ABS_X] = cliente.resx-1;
+		uidev.absmax[ABS_Y] = cliente.resy-1;
+	}
 	retval = write(cliente.ufile, &uidev, sizeof(uidev));
 
 	retval = ioctl(cliente.ufile, UI_DEV_CREATE);


### PR DESCRIPTION
Hi there!

I've noticed bug that causes invalid touchscreen positions being reported on my device.

When `-swap_axis` argument is used, driver uses correct resolution to determine where mouse cursor should be placed, but reports incorrect resolution to uinput. This causes mouse cursor being moved to wrong position with offset increasing towards right-down corner.

This PR fixes the problem.